### PR TITLE
Add parsing support

### DIFF
--- a/bigflake/bigflake.go
+++ b/bigflake/bigflake.go
@@ -87,7 +87,7 @@ func (bf *Bigflake) Mint() (*BigflakeId, error) {
 	}
 
 	// Mint a new ID
-	id := bf.mintId(bf.lastTimestamp, bf.workerId, bf.sequence, 48, 16)
+	id := bf.MintId(bf.lastTimestamp, bf.workerId, bf.sequence, 48, 16)
 	bfId := &BigflakeId{
 		id: id,
 	}
@@ -141,8 +141,9 @@ func (bf *Bigflake) update(t int64) error {
 	return nil
 }
 
-// mintId mints new 128bit IDs from the timestamp, worker ID and sequence
-func (bf *Bigflake) mintId(timestamp, workerid, sequence int64,
+// MintId mints new 128bit IDs from the timestamp, worker ID and sequence,
+// this should only be used directly for testing
+func (bf *Bigflake) MintId(timestamp, workerid, sequence int64,
 	workerIdBits, sequenceIdBits uint32) *big.Int {
 
 	// Time is the most significant bits

--- a/bigflake/bigflake.go
+++ b/bigflake/bigflake.go
@@ -87,7 +87,7 @@ func (bf *Bigflake) Mint() (*BigflakeId, error) {
 	}
 
 	// Mint a new ID
-	id := bf.MintId(bf.lastTimestamp, bf.workerId, bf.sequence, 48, 16)
+	id := MintId(bf.lastTimestamp, bf.workerId, bf.sequence, 48, 16)
 	bfId := &BigflakeId{
 		id: id,
 	}
@@ -143,7 +143,7 @@ func (bf *Bigflake) update(t int64) error {
 
 // MintId mints new 128bit IDs from the timestamp, worker ID and sequence,
 // this should only be used directly for testing
-func (bf *Bigflake) MintId(timestamp, workerid, sequence int64,
+func MintId(timestamp, workerid, sequence int64,
 	workerIdBits, sequenceIdBits uint32) *big.Int {
 
 	// Time is the most significant bits
@@ -163,4 +163,16 @@ func (bf *Bigflake) MintId(timestamp, workerid, sequence int64,
 	id = id.Or(id, bigS)
 
 	return id
+}
+
+func ParseId(id *big.Int, workerIdBits, sequenceIdBits uint32) (timestamp, workerid, sequence int64) {
+	bigS := big.NewInt(0)
+	bigW := big.NewInt(0)
+
+	bigS.And(id, big.NewInt((1<<sequenceIdBits)-1))
+	id.Rsh(id, uint(sequenceIdBits))
+	bigW.And(id, big.NewInt((1<<workerIdBits)-1))
+	id.Rsh(id, uint(workerIdBits))
+
+	return id.Int64(), bigW.Int64(), bigS.Int64()
 }

--- a/bigflake/bigflake.go
+++ b/bigflake/bigflake.go
@@ -87,7 +87,7 @@ func (bf *Bigflake) Mint() (*BigflakeId, error) {
 	}
 
 	// Mint a new ID
-	id := MintId(bf.lastTimestamp, bf.workerId, bf.sequence, 48, 16)
+	id := mintId(bf.lastTimestamp, bf.workerId, bf.sequence, bf.workerIdBits, bf.sequenceBits)
 	bfId := &BigflakeId{
 		id: id,
 	}
@@ -143,7 +143,11 @@ func (bf *Bigflake) update(t int64) error {
 
 // MintId mints new 128bit IDs from the timestamp, worker ID and sequence,
 // this should only be used directly for testing
-func MintId(timestamp, workerid, sequence int64,
+func MintId(timestamp, workerid, sequence int64) *big.Int {
+	return mintId(timestamp, workerid, sequence, defaultWorkerIdBits, defaultSequenceBits)
+}
+
+func mintId(timestamp, workerid, sequence int64,
 	workerIdBits, sequenceIdBits uint32) *big.Int {
 
 	// Time is the most significant bits
@@ -165,14 +169,14 @@ func MintId(timestamp, workerid, sequence int64,
 	return id
 }
 
-func ParseId(id *big.Int, workerIdBits, sequenceIdBits uint32) (timestamp, workerid, sequence int64) {
+func ParseId(id *big.Int) (timestamp, workerid, sequence int64) {
 	bigS := big.NewInt(0)
 	bigW := big.NewInt(0)
 
-	bigS.And(id, big.NewInt((1<<sequenceIdBits)-1))
-	id.Rsh(id, uint(sequenceIdBits))
-	bigW.And(id, big.NewInt((1<<workerIdBits)-1))
-	id.Rsh(id, uint(workerIdBits))
+	bigS.And(id, big.NewInt((1<<defaultSequenceBits)-1))
+	id.Rsh(id, uint(defaultSequenceBits))
+	bigW.And(id, big.NewInt((1<<defaultWorkerIdBits)-1))
+	id.Rsh(id, uint(defaultWorkerIdBits))
 
 	return id.Int64(), bigW.Int64(), bigS.Int64()
 }

--- a/bigflake/bigflake_test.go
+++ b/bigflake/bigflake_test.go
@@ -45,8 +45,8 @@ func TestParseBigFlake(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		id := MintId(tc.lastTs, tc.workerId, tc.sequence, defaultWorkerIdBits, defaultSequenceBits)
-		ts, workerId, sequence := ParseId(id, defaultWorkerIdBits, defaultSequenceBits)
+		id := MintId(tc.lastTs, tc.workerId, tc.sequence)
+		ts, workerId, sequence := ParseId(id)
 
 		assert.Equal(t, tc.lastTs, ts)
 		assert.Equal(t, tc.workerId, workerId)
@@ -76,7 +76,7 @@ func TestBigflakeSnowflakeMintCompatibility(t *testing.T) {
 	// Test that the bigflake minter generates snowflake compatible IDs
 	// when provided with the same test cases
 	for _, tc := range testCases {
-		id := MintId(tc.lastTs, tc.workerId, tc.sequence, 10, 12)
+		id := mintId(tc.lastTs, tc.workerId, tc.sequence, 10, 12)
 		assert.Equal(t, uint64(tc.id), id.Uint64(), fmt.Sprintf("IDs should match. Provided: '%d', Returned: '%s' ", tc.id, id))
 	}
 }
@@ -91,7 +91,7 @@ func BenchmarkMintBigflakeId(b *testing.B) {
 	// Zoom!
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		id = MintId(lastTs, workerId, sequenceId, 10, 12)
+		id = mintId(lastTs, workerId, sequenceId, 10, 12)
 	}
 
 	// always store the result to a package level variable

--- a/bigflake/bigflake_test.go
+++ b/bigflake/bigflake_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/mattheath/kala/util"
 )
@@ -25,6 +24,34 @@ func TestMintBigflakeId(t *testing.T) {
 		assert.NoError(t, err)
 	}
 	bigId = id
+}
+
+func TestParseBigFlake(t *testing.T) {
+	testCases := []struct {
+		lastTs   int64
+		workerId int64
+		sequence int64
+	}{
+		{1397666977000, 0, 0},     // Plain bit shift 22
+		{2344466898000, 0, 0},     // Plain bit shift 22
+		{1397666977000, 10, 0},    // Worker 10
+		{2344466898000, 10, 0},    // Worker 10
+		{1397666977000, 1023, 0},  // Worker 1023
+		{2344466898000, 1023, 0},  // Worker 1023
+		{1397666977000, 10, 123},  // Worker 10 & Sequence 123
+		{2344466898000, 10, 1230}, // Worker 10 & Sequence 1230
+		{1397666977000, 10, 2356}, // Worker 10 & Sequence 2356
+		{2344466898000, 10, 4090}, // Worker 10 & Sequence 4090
+	}
+
+	for _, tc := range testCases {
+		id := MintId(tc.lastTs, tc.workerId, tc.sequence, defaultWorkerIdBits, defaultSequenceBits)
+		ts, workerId, sequence := ParseId(id, defaultWorkerIdBits, defaultSequenceBits)
+
+		assert.Equal(t, tc.lastTs, ts)
+		assert.Equal(t, tc.workerId, workerId)
+		assert.Equal(t, tc.sequence, sequence)
+	}
 }
 
 func TestBigflakeSnowflakeMintCompatibility(t *testing.T) {
@@ -49,10 +76,8 @@ func TestBigflakeSnowflakeMintCompatibility(t *testing.T) {
 	// Test that the bigflake minter generates snowflake compatible IDs
 	// when provided with the same test cases
 	for _, tc := range testCases {
-		bf, err := New(0)
-		require.NoError(t, err)
-		id := bf.mintId(tc.lastTs, tc.workerId, tc.sequence, 10, 12)
-		assert.Equal(t, uint64(tc.id), id.Uint64(), fmt.Sprintf("IDs should match. Provided: '%s', Returned: '%s' ", tc.id, id))
+		id := MintId(tc.lastTs, tc.workerId, tc.sequence, 10, 12)
+		assert.Equal(t, uint64(tc.id), id.Uint64(), fmt.Sprintf("IDs should match. Provided: '%d', Returned: '%s' ", tc.id, id))
 	}
 }
 
@@ -62,12 +87,11 @@ func BenchmarkMintBigflakeId(b *testing.B) {
 
 	// Setup
 	lastTs, workerId, sequenceId = 1397666977000, 10, 2356
-	bf := &Bigflake{}
 
 	// Zoom!
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		id = bf.mintId(lastTs, workerId, sequenceId, 10, 12)
+		id = MintId(lastTs, workerId, sequenceId, 10, 12)
 	}
 
 	// always store the result to a package level variable

--- a/bigflake/sort_test.go
+++ b/bigflake/sort_test.go
@@ -69,7 +69,7 @@ func ksortability(t *testing.T, formatFunc func(id *BigflakeId) string) {
 		// Update time, sequence etc
 		err := bf.update(util.TimeToMsInt64(time.Now().Add(timeDiff)))
 		require.NoError(t, err)
-		id.id = bf.mintId(bf.lastTimestamp, bf.workerId, bf.sequence, 48, 16)
+		id.id = MintId(bf.lastTimestamp, bf.workerId, bf.sequence, 48, 16)
 
 		idStr := formatFunc(id)
 

--- a/bigflake/sort_test.go
+++ b/bigflake/sort_test.go
@@ -69,7 +69,7 @@ func ksortability(t *testing.T, formatFunc func(id *BigflakeId) string) {
 		// Update time, sequence etc
 		err := bf.update(util.TimeToMsInt64(time.Now().Add(timeDiff)))
 		require.NoError(t, err)
-		id.id = MintId(bf.lastTimestamp, bf.workerId, bf.sequence, 48, 16)
+		id.id = MintId(bf.lastTimestamp, bf.workerId, bf.sequence)
 
 		idStr := formatFunc(id)
 

--- a/util/util.go
+++ b/util/util.go
@@ -28,5 +28,7 @@ func TimeToMsInt64(t time.Time) int64 {
 }
 
 func MsInt64ToTime(msInt int64) time.Time {
-	return time.Unix(0, msInt*int64(time.Millisecond)).UTC()
+	secs := msInt / 1e3
+	ns := (msInt % 1e3) * 1e6
+	return time.Unix(secs, ns).UTC()
 }

--- a/util/util.go
+++ b/util/util.go
@@ -26,3 +26,7 @@ func CustomTimestamp(epoch int64, t time.Time) int64 {
 func TimeToMsInt64(t time.Time) int64 {
 	return int64(t.UTC().Unix()*1e3) + int64(t.UTC().Nanosecond()/1e6)
 }
+
+func MsInt64ToTime(msInt int64) time.Time {
+	return time.Unix(0, msInt*int64(time.Millisecond)).UTC()
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -13,7 +13,7 @@ func TestMacAddressToWorkerId(t *testing.T) {
 	mac := "80:36:bc:db:64:16"
 	workerId, err := MacAddressToWorkerId(mac)
 	require.NoError(t, err)
-	assert.Equal(t, uint(140972585083926), workerId)
+	assert.EqualValues(t, 140972585083926, workerId)
 }
 
 func TestCustomTimestamp(t *testing.T) {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -78,5 +78,8 @@ func TestTimeToMsInt64(t *testing.T) {
 		t.Logf("%s :: %v", tc.timestamp, ms)
 
 		assert.Equal(t, tc.expected, ms, fmt.Sprintf("Expected %s", tc.timestamp))
+
+		ts2 := MsInt64ToTime(ms)
+		assert.Equal(t, ts.Truncate(time.Millisecond).String(), ts2.Truncate(time.Millisecond).String())
 	}
 }


### PR DESCRIPTION
`bf.mintId` is now `MintId`, it didn't use any of the fields on `bf` so there was no reason for it to be a method. Since it was unexported this change is fully backwards compatible.

It is now exported to make writing unit tests that require flake IDs that span a certain time range possible.

There is a new method and unit test for parsing an id back into timestamp, worker id and sequence.
