### PR TITLE
Added method to expose snowflake ids as uint64

### DIFF
--- a/snowflake/snowflake.go
+++ b/snowflake/snowflake.go
@@ -72,7 +72,7 @@ type Snowflake struct {
 }
 
 // Mint a new 64bit ID based on the current time, worker id and sequence
-func (sf *Snowflake) Mint() (string, error) {
+func (sf *Snowflake) MintID() (uint64, error) {
 	sf.Lock()
 	defer sf.Unlock()
 
@@ -81,7 +81,7 @@ func (sf *Snowflake) Mint() (string, error) {
 
 	// Ensure we only mint IDs if correctly configured
 	if sf.workerId > sf.maxWorkerId {
-		return "", ErrInvalidWorkerId
+		return 0, ErrInvalidWorkerId
 	}
 
 	// Get the current timestamp in ms, adjusted to our custom epoch
@@ -90,11 +90,20 @@ func (sf *Snowflake) Mint() (string, error) {
 	// Update snowflake with this, which will increment sequence number if needed
 	err := sf.update(t)
 	if err != nil {
-		return "", err
+		return 0, err
 	}
 
 	// Mint a new ID
 	id := sf.mintId()
+
+	return id, nil
+}
+
+func (sf *Snowflake) Mint() (string, error) {
+	id, err := sf.MintID()
+	if err != nil {
+		return "", err
+	}
 
 	return strconv.FormatUint(id, 10), nil
 }


### PR DESCRIPTION
Having ids in `uint64` format is more useful and flexible.
