### PR TITLE
Allow recreation of bigflake.BigFlakeId from big.Int

### DIFF
--- a/bigflake/id.go
+++ b/bigflake/id.go
@@ -10,6 +10,11 @@ import (
 	"github.com/mattheath/base62"
 )
 
+// NewId creates a BigflakeId from a big.Int
+func NewId(id *big.Int) *BigflakeId {
+	return &BigflakeId{id}
+}
+
 // BigflakeId represents a globally unique ID
 type BigflakeId struct {
 	id *big.Int

--- a/snowflake/snowflake_test.go
+++ b/snowflake/snowflake_test.go
@@ -146,7 +146,7 @@ func TestMintId(t *testing.T) {
 		sf.sequence = tc.sequence
 
 		id := sf.mintId()
-		assert.Equal(t, tc.id, id, fmt.Sprintf("IDs should match. Provided: '%s', Returned: '%s' ", tc.id, id))
+		assert.Equal(t, tc.id, id, fmt.Sprintf("IDs should match. Provided: '%v', Returned: '%v' ", tc.id, id))
 	}
 }
 


### PR DESCRIPTION
This PR adds a function `bigflake.NewId()` to create a `bigflake.BigflakeId` from a `big.Int`. This will make it easier to marshal "raw" big flake IDs for persistence purposes.